### PR TITLE
Fix misalignment in signatures for methods with `@support_batches`

### DIFF
--- a/easy_entrez/batch.py
+++ b/easy_entrez/batch.py
@@ -29,14 +29,14 @@ def supports_batches(func):
     """
 
     @wraps(func)
-    def batches_support_wrapper(self: 'EntrezAPI', collection: Sequence, *args, **kwargs):
+    def batches_support_wrapper(self: 'EntrezAPI', ids: Sequence, *args, **kwargs):
         size = self._batch_size
         interval = self._batch_sleep_interval
         if size is not None:
             assert isinstance(size, int)
             by_batch = {}
 
-            for i, batch in enumerate(tqdm(batches(collection, size=size))):
+            for i, batch in enumerate(tqdm(batches(ids, size=size))):
                 done = False
 
                 while not done:
@@ -62,7 +62,7 @@ def supports_batches(func):
                 sleep(interval)
             return by_batch
         else:
-            return func(self, collection, *args, **kwargs)
+            return func(self, ids, *args, **kwargs)
 
     if not batches_support_wrapper.__doc__:
         batches_support_wrapper.__doc__ = ''

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -9,8 +9,8 @@ entrez_api = EntrezAPI(
     'easy-entrez-test',
     'krassowski.michal+easyentrez@mail.com',
     return_type='json',
-    # 2 seconds interval as these tests are less urgent than any actual research
-    minimal_interval=2
+    # 3 seconds interval as these tests are less urgent than any actual research
+    minimal_interval=3
 )
 
 
@@ -41,3 +41,14 @@ def test_fetch():
 
     with raises(ValueError, match='Received str but a list-like container of identifiers was expected'):
         entrez_api.fetch('4', max_results=1, database='snp')
+
+
+def test_link():
+    # https://github.com/krassowski/easy-entrez/issues/2
+    result = entrez_api.link(
+        database=None,
+        ids=[15718680, 157427902],
+        database_from='protein',
+        command='acheck'
+    )
+    assert result.data


### PR DESCRIPTION
Fixes #2.

This is breaking in the sense that passing `collection=[...]` will no longer work.

Ideally it would be rewritten to:
- use `inspect` module to get func signature
- accept either collection or ids