### PR TITLE
Get coding consequence, add range example

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
         package_data={'easy_entrez': ['data/*.tsv', 'py.typed']},
         # required for mypy to work
         zip_safe=False,
-        version='0.3.4',
+        version='0.3.5',
         license='MIT',
         description='Python REST API for Entrez E-Utilities: stateless, easy to use, reliable.',
         long_description=get_long_description('README.md'),


### PR DESCRIPTION
Parses `DOCSUM` field for convenience, adds an example on extracting out the coding change information