### PR TITLE
Document batching in README, parse snp batch results

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,20 @@ protein_hgvs.head()
 > | rs1940853299 | NP_006437.3 | p.Lys201Thr |
 > | rs1940852987 | NP_006437.3 | p.Asp198Glu |
 
+#### Fetching more than 10 000 entries
+
+Use `in_batches_of` method to fetch more than 10k entries (e.g. `variant_ids`):
+
+```python
+snps_result = (
+    entrez.api
+    .in_batches_of(1_000)
+    .fetch(variant_ids, max_results=5_000, database='snp')
+)
+```
+
+The result is a dictionary with keys being identifiers used in each batch (because the Entrez API does not always return the indentifiers back) and values representing the result. You can use `parse_dbsnp_variants` directly on this dictionary.
+
 #### Find PubMed ID from DOI
 
 When searching GWAS catalog PMID is needed over DOI. You can covert one to the other using:

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ if __name__ == '__main__':
         package_data={'easy_entrez': ['data/*.tsv', 'py.typed']},
         # required for mypy to work
         zip_safe=False,
-        version='0.3.5',
+        version='0.3.6',
         license='MIT',
         description='Python REST API for Entrez E-Utilities: stateless, easy to use, reliable.',
         long_description=get_long_description('README.md'),

--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -76,6 +76,17 @@ def test_parse_two_snps():
 
 
 @pytest.mark.optional
+def test_parse_batch():
+    response = DummyResponse(
+        query=FetchQuery(ids=['rs6311', 'rs662138'], database='snp', max_results=10),
+        content_type='xml',
+        data=fromstring(TWO_SNPS)
+    )
+    variant_set = parse_dbsnp_variants({('rs6311', 'rs662138'): response})
+    assert type(variant_set) == VariantSet
+
+
+@pytest.mark.optional
 def test_merged_variant_solving():
     response = DummyResponse(
         query=FetchQuery(ids=['rs59679468'], database='snp', max_results=10),


### PR DESCRIPTION
Document batching in README, accept snp batch results in `parse_dbsnp_variants()`