### PR TITLE
Allow to disable Entrez search result limit

### DIFF
--- a/easy_entrez/api.py
+++ b/easy_entrez/api.py
@@ -142,13 +142,17 @@ class EntrezAPI:
     @uses_query(SearchQuery)
     def search(
         self, term: Union[str, dict], max_results: int,
-        database: EntrezDatabase = 'pubmed', min_date=None, max_date=None
+        database: EntrezDatabase = 'pubmed', min_date=None, max_date=None,
+        ignore_max_results_limit: bool = False
     ):
         if isinstance(term, dict):
             term = _match_all(**term)
 
         assert not min_date and not max_date  # TODO
-        query = SearchQuery(term=term, max_results=max_results, database=database)
+        query = SearchQuery(
+            term=term, max_results=max_results, database=database,
+            ignore_max_results_limit=ignore_max_results_limit
+        )
         return self._request(query=query)
 
     def in_batches_of(self, size: int = 100, sleep_interval: int = 3):
@@ -161,20 +165,27 @@ class EntrezAPI:
     @uses_query(SummaryQuery)
     def summarize(
         self, ids: List[str], max_results: int,
-        database: EntrezDatabase = 'pubmed'
+        database: EntrezDatabase = 'pubmed', ignore_max_results_limit: bool = False
     ):
         self._ensure_list_like(ids)
-        query = SummaryQuery(ids=ids, max_results=max_results, database=database)
+        query = SummaryQuery(
+            ids=ids, max_results=max_results, database=database,
+            ignore_max_results_limit=ignore_max_results_limit
+        )
         return self._request(query=query)
 
     @supports_batches
     @uses_query(FetchQuery)
     def fetch(
         self, ids: List[str], max_results: int,
-        database: EntrezDatabase = 'pubmed', return_type: ReturnType = 'xml'
+        database: EntrezDatabase = 'pubmed', return_type: ReturnType = 'xml',
+        ignore_max_results_limit: bool = False
     ):
         self._ensure_list_like(ids)
-        query = FetchQuery(ids=ids, max_results=max_results, database=database, return_type=return_type)
+        query = FetchQuery(
+            ids=ids, max_results=max_results, database=database,
+            return_type=return_type, ignore_max_results_limit=ignore_max_results_limit
+        )
         return self._request(query=query)
 
     @supports_batches

--- a/easy_entrez/queries.py
+++ b/easy_entrez/queries.py
@@ -90,8 +90,8 @@ class SearchQuery(EntrezQuery):
 
     def validate(self):
         super().validate()
-        if self.max_results > 100_000:
-            raise ValueError('Fetching more than 100,000 results is not implemented')
+        if self.max_results > 10_000:
+            raise ValueError('Fetching more than 10,000 results is not implemented')
 
     def to_params(self) -> Dict[str, str]:
         params = super().to_params()

--- a/easy_entrez/queries.py
+++ b/easy_entrez/queries.py
@@ -82,15 +82,21 @@ class SearchQuery(EntrezQuery):
         database: Database to search.
             Value must be a valid E-utility database name (default = :py:obj:`'pubmed'`).
         term: Entrez text query
-        max_results: maximal number of results to return
+        max_results: Maximal number of results to return. Limited to 10'000, following
+            the eUtils documentation.
+        ignore_max_results_limit: Ignore the upper limit placed on max_results.
+            Experimentation has shown that some databases allow for higher limits, but
+            as this is not documented, setting higher limits needs to be explicitly
+            enabled here. Use at your own risk of hard to predict errors.
     """
     endpoint = 'esearch'
     term: str
     max_results: int
+    ignore_max_results_limit: bool = False
 
     def validate(self):
         super().validate()
-        if self.max_results > 10_000:
+        if self.max_results > 10_000 and not self.ignore_max_results_limit:
             raise ValueError('Fetching more than 10,000 results is not implemented')
 
     def to_params(self) -> Dict[str, str]:
@@ -124,16 +130,22 @@ class SummaryQuery(EntrezQuery):
             There is no set maximum for the number of UIDs that can be passed to ESummary.
             To comply with the recommendation of using HTTP POST method if lists of UIDs for ESummary is long,
             the method is by default set to `post`.
-        max_results: maximal number of results to return
+        max_results: Maximal number of results to return. Limited to 10'000, following
+            the eUtils documentation.
+        ignore_max_results_limit: Ignore the upper limit placed on max_results.
+            Experimentation has shown that some databases allow for higher limits, but
+            as this is not documented, setting higher limits needs to be explicitly
+            enabled here. Use at your own risk of hard to predict errors.
     """
     endpoint = 'esummary'
     method = 'post'
     ids: List[Identifier]
     max_results: int
+    ignore_max_results_limit: bool = False
 
     def validate(self):
         super().validate()
-        if self.max_results > 10_000:
+        if self.max_results > 10_000 and not self.ignore_max_results_limit:
             raise ValueError('Fetching more than 10,000 results is not implemented')
 
     def to_params(self) -> Dict[str, str]:


### PR DESCRIPTION
Fixes the limit on `max_results` for `EntrezAPI.search()` and adds an option to ignore all similar limits.

Should pretty much close #16, at least for my purposes.

Note: Running `pytest` on commit [3c2b396](https://github.com/krassowski/easy-entrez/pull/18/commits/3c2b39663fd5882880f7625db47316ae68c2cc7c) resulted in the following output once, but the error disappeared after I ran it again without changing anything, the programmers ~dream~ nightmare.



```
(.venv) jfreige@sl-akali-p-cs1:easy-entrez (16-entrez-result-limit)$ pytest
============================================================================================== test session starts ===============================================================================================
platform linux -- Python 3.10.12, pytest-7.4.2, pluggy-1.3.0
rootdir: /data/local/jfreige/geo-mining/easy-entrez
plugins: cov-4.1.0
collected 15 items                                                                                                                                                                                               

tests/test_api.py ..F                                                                                                                                                                                      [ 20%]
tests/test_parsing.py ....                                                                                                                                                                                 [ 46%]
tests/test_queries.py ........                                                                                                                                                                             [100%]

==================================================================================================== FAILURES ====================================================================================================
___________________________________________________________________________________________________ test_fetch ___________________________________________________________________________________________________

    def test_fetch():
        result = entrez_api.fetch(['4'], max_results=1, database='snp')
        assert is_response_for(result, FetchQuery)
        assert not is_response_for(result, SearchQuery)
        snp = result.data[0]
        namespaces = {'ns0': 'https://www.ncbi.nlm.nih.gov/SNP/docsum'}
>       chromosome = snp.find('.//ns0:CHR', namespaces).text
E       AttributeError: 'NoneType' object has no attribute 'text'

tests/test_api.py:38: AttributeError
================================================================================================ warnings summary ================================================================================================
tests/test_parsing.py:39
  /data/local/jfreige/geo-mining/easy-entrez/tests/test_parsing.py:39: PytestUnknownMarkWarning: Unknown pytest.mark.optional - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.optional

tests/test_parsing.py:78
  /data/local/jfreige/geo-mining/easy-entrez/tests/test_parsing.py:78: PytestUnknownMarkWarning: Unknown pytest.mark.optional - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.optional

tests/test_parsing.py:89
  /data/local/jfreige/geo-mining/easy-entrez/tests/test_parsing.py:89: PytestUnknownMarkWarning: Unknown pytest.mark.optional - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/how-to/mark.html
    @pytest.mark.optional

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
============================================================================================ short test summary info =============================================================================================
FAILED tests/test_api.py::test_fetch - AttributeError: 'NoneType' object has no attribute 'text'
==================================================================================== 1 failed, 14 passed, 3 warnings in 4.47s ====================================================================================```