### PR TITLE
Add new format RDT config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,9 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"
+
+sphinx:
+  configuration: docs/conf.py

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -7,3 +7,10 @@ build:
 
 sphinx:
   configuration: docs/conf.py
+
+python:
+  install:
+    - method: pip
+      path: .
+      extra_requirements:
+        - docs

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Easy-entrez:
 
 - makes common tasks easy thanks to simple Pythonic API,
 - is typed and integrates well with mypy,
-- is tested on Windows, Mac and Linux across Python 3.7, 3.8, 3.9 and 3.10,
+- is tested on Windows, Mac and Linux across Python 3.7, 3.8, 3.9, 3.10 and 3.11
 - is limited in scope, allowing to focus on the reliability of the core code,
 - does not use the stateful API as it is [error-prone](https://gitlab.com/ncbipy/entrezpy/-/issues/7) as seen on example of the alternative *entrezpy*.
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -1,5 +1,4 @@
 -r ./minimal.txt
 -r ./optional.txt
--r ./docs.txt
 pytest
 pytest-cov

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,0 @@
--r ./minimal.txt
-sphinx<6.0
-pydata-sphinx-theme
-sphinx-autodoc-typehints
-sphinx-copybutton
-myst-parser

--- a/setup.py
+++ b/setup.py
@@ -46,6 +46,13 @@ if __name__ == '__main__':
         install_requires=['requests', 'typing_extensions', 'dataclasses>="0.7";python_version<"3.7"'],
         extras_require={
             'with_progress_bars': ['tqdm'],
-            'with_parsing_utils': ['pandas']
+            'with_parsing_utils': ['pandas'],
+            'docs': [
+                'sphinx<6.0',
+                'pydata-sphinx-theme',
+                'sphinx-autodoc-typehints',
+                'sphinx-copybutton',
+                'myst-parser'
+            ]
         }
     )

--- a/setup.py
+++ b/setup.py
@@ -36,14 +36,13 @@ if __name__ == '__main__':
             'Typing :: Typed',
             'Intended Audience :: Developers',
             'Intended Audience :: Science/Research',
-            'Programming Language :: Python :: 3.6',
             'Programming Language :: Python :: 3.7',
             'Programming Language :: Python :: 3.8',
             'Programming Language :: Python :: 3.9',
             'Programming Language :: Python :: 3.10',
             'Programming Language :: Python :: 3.11'
         ],
-        install_requires=['requests', 'typing_extensions', 'dataclasses>="0.7";python_version<"3.7"'],
+        install_requires=['requests', 'typing_extensions'],
         extras_require={
             'with_progress_bars': ['tqdm'],
             'with_parsing_utils': ['pandas'],


### PR DESCRIPTION
- Fix the docs job
- Drops Python 3.6 support (which reached EOL almost two years ago, 2021-12-23)