### PR TITLE
Silence pytest warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,4 @@
+[tool.pytest.ini_options]
+markers = [
+    "optional: marks tests as optional (deselect with '-m \"not optional\"')",
+]


### PR DESCRIPTION
  The whole reason is to silence the pytest warnings about undefined optional marks on pytests.