### PR TITLE
Adding `requirements.docs.txt`

### DIFF
--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,0 +1,6 @@
+myst-parser
+pydata-sphinx-theme
+sphinx
+sphinx-autodoc-typehints
+sphinx-copybutton
+sphinx_rtd_theme


### PR DESCRIPTION
Making it clear what packages are necessary to locally build `docs/` from the repo root:

```bash
sphinx-build docs docs/_build
open docs/_build/index.html
```